### PR TITLE
Remove universal flag from bdist_wheel config

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -11,9 +11,6 @@ replace = version='{new_version}'
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude = docs
 


### PR DESCRIPTION
Remove universal flag from bdist_wheel config since Python 2 is no
longer supported in this project.

@see https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels

I found some commits with intention to end Python 2 support:
- https://github.com/briggySmalls/cookiecutter-pypackage/commit/6c7f1c40559ac9ed043d98406732b1f2c8315137
- https://github.com/briggySmalls/cookiecutter-pypackage/commit/7ab4e43224c148be4d16f951a3d0ec207ba4c4b4