### PR TITLE
Remove dependency pathlib2 from tox.ini

### DIFF
--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -21,7 +21,6 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     pipenv
-    {py27}: pathlib2
 ; If you want to make tox run the tests with the same versions, commit
 ; the Pipfile.lock to source control and remove the --skip-lock below
 commands_pre = pipenv install --dev --skip-lock


### PR DESCRIPTION
Remove dependency pathlib2 from tox.ini since Python 2 is no longer
supported in this project.

@see https://tox.readthedocs.io/en/latest/config.html#generating-environments-conditional-settings
@see https://tox.readthedocs.io/en/latest/config.html#complex-factor-conditions

\# Conflicts:
\#	{{cookiecutter.project_slug}}/tox.ini