### PR TITLE
Fix project slug name convention

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,7 @@
   "github_username": "yukihiko-shinoda",
   "project_name": "Python Boilerplate",
   "github_repository_name": "{{ cookiecutter.project_name.lower().replace(' ', '-').replace('_', '-') }}",
-  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
+  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '').replace('-', '').replace('_', '') }}",
   "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
   "pypi_username": "{{ cookiecutter.github_username }}",
   "version": "0.1.0",

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -86,7 +86,7 @@ def test_bake_with_defaults(cookies):
         assert result.exit_code == 0
         assert result.exception is None
         check_toplevel_path_exist(
-            result, ["setup.py", "python_boilerplate", "tox.ini", "tests"]
+            result, ["setup.py", "pythonboilerplate", "tox.ini", "tests"]
         )
 
 
@@ -284,7 +284,7 @@ def test_using_pytest(cookies):
         lines = pipfile_file_path.readlines()
         assert 'pytest = "*"\n' in lines
         # Test contents of test file
-        test_file_path = result.project.join("tests/test_python_boilerplate.py")
+        test_file_path = result.project.join("tests/test_pythonboilerplate.py")
         lines = test_file_path.readlines()
         assert "import pytest" in "".join(lines)
         # Test the new pytest target
@@ -306,7 +306,7 @@ def test_not_using_pytest(cookies):
         lines = pipfile_file_path.readlines()
         assert 'pytest = "*"\n' not in lines
         # Test contents of test file
-        test_file_path = result.project.join("tests/test_python_boilerplate.py")
+        test_file_path = result.project.join("tests/test_pythonboilerplate.py")
         lines = test_file_path.readlines()
         assert "import unittest" in "".join(lines)
         assert "import pytest" not in "".join(lines)


### PR DESCRIPTION
@see https://www.python.org/dev/peps/pep-0008/#package-and-module-names
@see https://www.python.org/dev/peps/pep-0423/#follow-pep-8-for-syntax-of-package-and-module-names
@see https://www.python.org/dev/peps/pep-0423/#use-a-single-name