### PR TITLE
Fix bug around bump2version

### DIFF
--- a/{{cookiecutter.github_repository_name}}/.bumpversion.cfg
+++ b/{{cookiecutter.github_repository_name}}/.bumpversion.cfg
@@ -3,10 +3,10 @@ current_version = {{ cookiecutter.version }}
 commit = True
 tag = True
 
-[bumpversion:file:pyproject.toml]
-search = version = "{current_version}"
-replace = version = "{new_version}"
+[bumpversion:file:setup.py]
+search = version="{current_version}"
+replace = version="{new_version}"
 
 [bumpversion:file:{{ cookiecutter.project_slug }}/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/{{cookiecutter.github_repository_name}}/setup.cfg
+++ b/{{cookiecutter.github_repository_name}}/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = {{ cookiecutter.version }}
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:{{ cookiecutter.project_slug }}/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [flake8]
 exclude = docs
 # @see https://github.com/psf/black/blob/master/README.md#line-length


### PR DESCRIPTION
- Fix bug that bump2version configure remains in setup.cfg even though
  bumpversion.cfg exists.
- Fix bug that target update file isn't setup.py but pyproject.toml.
- Fix bug that bumpversion command breaks file since configure uses
  single quote even though black formats by double quote.