### PR TITLE
Set min-public-methods 1

### DIFF
--- a/{{cookiecutter.github_repository_name}}/pyproject.toml
+++ b/{{cookiecutter.github_repository_name}}/pyproject.toml
@@ -27,3 +27,8 @@ max-line-length = "{{ cookiecutter.python_code_max_length_per_line }}"
 disable = ''',
     bad-continuation,
     '''
+
+[tool.pylint.options]
+# Since this rule against single responsibility principle.
+# @see https://stackoverflow.com/questions/28722314/why-does-pylint-want-2-public-methods-per-class/40258006#40258006
+min-public-methods = "1"


### PR DESCRIPTION
Since this rule against single responsibility principle.
@see https://stackoverflow.com/questions/28722314/why-does-pylint-want-2-public-methods-per-class/40258006#40258006