### PR TITLE
Organize dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,53 +1,14 @@
 [dependency-groups]
 dev = [
-    "bandit",
     "bump-my-version",
     # To test baked cli.py
     # 2025-06-15: Since the latest Semgrep depends on click<8.2.dev0,
     # otherwise too legacy version of click is installed and it can't run in Windows.
     "click<8.2.0",
-    "cohesion",
-    # The coverage==3.5.3 is difficult to analyze its dependencies by dependencies management tool,
-    # so we should avoid 3.5.3 or lower.
-    # - Command: "pipenv install --skip-lock" fails 
-    #   since it tries to parse legacy package metadata and raise InstallError
-    #   · Issue #5595 · pypa/pipenv
-    #   https://github.com/pypa/pipenv/issues/5595
-    "coverage>=3.5.4",
-    # The dlint less than 0.14.0 limits max version of flake8.
-    # - dlint/requirements.txt at 0.13.0 · dlint-py/dlint
-    #   https://github.com/dlint-py/dlint/blob/0.13.0/requirements.txt#L1
-    "dlint>=0.14.0",
-    # To the docformatter load pyproject.toml settings:
-    # docformatter < 1.7.8 depends on untokenize==0.1.1, whose setup.py uses ast.Constant.s removed in Python 3.14:
-    # - Installation fails on Python 3.14 · Issue #327 · PyCQA/docformatter
-    #   https://github.com/PyCQA/docformatter/issues/327
-    # uv builds packages using the current interpreter to collect metadata for the lock file, so even a marker
-    # like `python_version < '3.14'` cannot prevent the build from running on Python 3.14 and failing.
-    # docformatter >= 1.7.8 dropped untokenize but requires Python >= 3.10, so Python 3.7-3.9 are excluded.
-    "docformatter[tomli]>=1.7.8; python_version >= '3.10' and python_version < '3.11'",
-    "docformatter>=1.7.8; python_version >= '3.11'",
-    "dodgy",
-    # The hacking depends flake8 ~=6.1.0 or ~=5.0.1 or ~=4.0.1.
-    # We should avoid the versions that is not compatible with the hacking,
-    # considering the speed of dependency calculation process
-    "flake8!=6.0.0,!=5.0.0,>=4.0.1",
-    # To replace E501 in pycodestyle with B950 in flake8-bugbear:
-    # - Using Black with other tools - Black 25.1.0 documentation
-    #   https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#bugbear
-    "flake8-bugbear",
-    # To use pyproject.toml for Flake8 configuration
-    "Flake8-pyproject",
-    # Latest hacking depends on legacy version of flake8, and legacy hacking doesn't narrow flake8 version.
-    # When unpin hacking, it has possibility to install too legacy version of hacking.
-    "hacking>=5.0.0; python_version >= '3.8'",
-    "invokelint",
+    "invokelint[basic]>=0.19.0",
     # To enable 2 spaces indent list in mkdocs
     "mdx-truly-sane-lists",
     "mkdocs",
-    "mypy",
-    "pylint",
-    "pytest",
     # see:
     # - fix: Replace `"` with `'` in user config template by andriihomiak · Pull Request #61 · hackebrot/pytest-cookies
     #   https://github.com/hackebrot/pytest-cookies/pull/61
@@ -58,16 +19,6 @@ dev = [
     "pytest-resource-path",
     "pyvelocity; python_version >= '3.9'",
     "pyyaml",
-    "ruff",
-   # If we simply lock as "semgrep; python_version >= '3.9' or python_version>='3.6' and platform_system=='Linux'",
-    # the semgrep 1.121.0 is installed in Python 3.14 and cause following error:
-    #     File "/root/.local/share/uv/python/cpython-3.14.5-linux-aarch64-gnu/lib/python3.14/importlib/__init__.py", line 88, in import_module
-    #       return _bootstrap._gcd_import(name[level:], package, level)
-    #              ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    #   TypeError: Metaclasses with custom tp_new are not supported.
-    "semgrep; python_version >= '3.9' and python_version < '3.10' or python_version>='3.6' and platform_system=='Linux'",
-    "semgrep>=1.122.0;python_version >= '3.10'",
-    "types-invoke",
     "types-setuptools",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,13 @@ external = [
     "DUO",  # dlint
     "H",    # Openstack/hacking
 ]
-select = ["ALL"]
+select = [
+    "ALL",
+    # Since compatible with PEP257, we can check docstring style by Ruff and don't need to consider about docstring style separately:
+    # - Should the first line of a Python function docstring be in imperative mood? (ruff / pydocstyle D401)
+    #   https://zenn.dev/y_shinoda/articles/pydocstyle-d401
+    "D401",    # First line should be in imperative mood
+]
 ignore = [
     # lint.pydocstyle
     # Reason: Docstring may be missed since docstring-min-length is set.

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -336,8 +336,6 @@ def test_not_using_pytest(baked_in_temp_dir: Result) -> None:
     import pytest.
     """
     assert baked_in_temp_dir.project_path.is_dir()
-    # Test Pipfile doesn install pytest
-    assert not pytest_entry_exists_in_pyproject_toml(baked_in_temp_dir)
     # Test conftest.py not exist
     assert not conftest_exists(baked_in_temp_dir)
     # Test contents of test file
@@ -371,7 +369,7 @@ def get_test_file_text(baked_in_temp_dir: Result) -> str:
 def pytest_entry_exists_in_pyproject_toml(result: Result) -> bool:
     pipfile_file_path = result.project_path / "pyproject.toml"
     lines = pipfile_file_path.read_text(encoding="utf-8").splitlines()
-    return '    "pytest",' in lines
+    return any("invokelint[basic]" in line for line in lines)
 
 
 # def test_project_with_hyphen_in_module_name(cookies):

--- a/{{cookiecutter.github_repository_name}}/pyproject.dist.toml
+++ b/{{cookiecutter.github_repository_name}}/pyproject.dist.toml
@@ -177,7 +177,13 @@ external = [
     "DUO",  # dlint
     "H",    # Openstack/hacking
 ]
-select = ["ALL"]
+select = [
+    "ALL",
+    # Since compatible with PEP257, we can check docstring style by Ruff and don't need to consider about docstring style separately:
+    # - Should the first line of a Python function docstring be in imperative mood? (ruff / pydocstyle D401)
+    #   https://zenn.dev/y_shinoda/articles/pydocstyle-d401
+    "D401",    # First line should be in imperative mood
+]
 ignore = [
     # lint.pydocstyle
     # Reason: Docstring may be missed since docstring-min-length is set.

--- a/{{cookiecutter.github_repository_name}}/pyproject.dist.toml
+++ b/{{cookiecutter.github_repository_name}}/pyproject.dist.toml
@@ -4,61 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [dependency-groups]
 dev = [
-    "bandit",
-    "build",
     "bump-my-version",
-    "cohesion",
-    # The coverage==3.5.3 is difficult to analyze its dependencies by dependencies management tool,
-    # so we should avoid 3.5.3 or lower.
-    # - Command: "pipenv install --skip-lock" fails 
-    #   since it tries to parse legacy package metadata and raise InstallError
-    #   · Issue #5595 · pypa/pipenv
-    #   https://github.com/pypa/pipenv/issues/5595
-    "coverage>=3.5.4",
-    # The dlint less than 0.14.0 limits max version of flake8.
-    # - dlint/requirements.txt at 0.13.0 · dlint-py/dlint
-    #   https://github.com/dlint-py/dlint/blob/0.13.0/requirements.txt#L1
-    "dlint>=0.14.0",
-    # To the docformatter load pyproject.toml settings:
-    # docformatter < 1.7.8 depends on untokenize==0.1.1, whose setup.py uses ast.Constant.s removed in Python 3.14:
-    # - Installation fails on Python 3.14 · Issue #327 · PyCQA/docformatter
-    #   https://github.com/PyCQA/docformatter/issues/327
-    # uv builds packages using the current interpreter to collect metadata for the lock file, so even a marker
-    # like `python_version < '3.14'` cannot prevent the build from running on Python 3.14 and failing.
-    # docformatter >= 1.7.8 dropped untokenize but requires Python >= 3.10, so Python 3.7-3.9 are excluded.
-    "docformatter[tomli]>=1.7.8; python_version >= '3.10' and python_version < '3.11'",
-    "docformatter>=1.7.8; python_version >= '3.11'",
-    "dodgy",
-    # The hacking depends flake8 ~=6.1.0 or ~=5.0.1 or ~=4.0.1.
-    # We should avoid the versions that is not compatible with the hacking,
-    # considering the speed of dependency calculation process
-    "flake8!=6.0.0,!=5.0.0,>=4.0.1",
-    # To replace E501 in pycodestyle with B950 in flake8-bugbear:
-    # - Using Black with other tools - Black 25.1.0 documentation
-    #   https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#bugbear
-    "flake8-bugbear",
-    # To use pyproject.toml for Flake8 configuration
-    "Flake8-pyproject",
-    # Latest hacking depends on legacy version of flake8, and legacy hacking doesn't narrow flake8 version.
-    # When unpin hacking, it has possibility to install too legacy version of hacking.
-    "hacking>=5.0.0; python_version >= '3.8'",
-    "invokelint>=0.8.1",
-    "mypy",
-    "pylint",
-    {% if cookiecutter.use_pytest == 'y' -%}
-    "pytest",
-    {% endif -%}
+    "invokelint[basic]>=0.19.0",
     "pyvelocity; python_version >= '3.9'",
-    "ruff",
-   # If we simply lock as "semgrep; python_version >= '3.9' or python_version>='3.6' and platform_system=='Linux'",
-    # the semgrep 1.121.0 is installed in Python 3.14 and cause following error:
-    #     File "/root/.local/share/uv/python/cpython-3.14.5-linux-aarch64-gnu/lib/python3.14/importlib/__init__.py", line 88, in import_module
-    #       return _bootstrap._gcd_import(name[level:], package, level)
-    #              ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    #   TypeError: Metaclasses with custom tp_new are not supported.
-    "semgrep; python_version >= '3.9' and python_version < '3.10' or python_version>='3.6' and platform_system=='Linux'",
-    "semgrep>=1.122.0;python_version >= '3.10'",
-    "types-invoke",
 ]
 
 {% set license_classifiers = {


### PR DESCRIPTION
This pull request simplifies and updates the development dependencies and linting configuration for the project. The main changes are the removal of several linting and testing tools in favor of using `invokelint[basic]`, and an update to the Ruff linting configuration to explicitly include the D401 docstring rule. The test logic is also updated to reflect these dependency changes.

**Dependency updates and cleanup:**

- Removed multiple development dependencies such as `bandit`, `cohesion`, `coverage`, `dlint`, `docformatter`, `dodgy`, `flake8`, `flake8-bugbear`, `Flake8-pyproject`, `hacking`, `mypy`, `pylint`, `pytest`, `ruff`, `semgrep`, and `types-invoke` from the `dev` group in both `pyproject.toml` and the template `pyproject.dist.toml`. Instead, added or updated `invokelint[basic]>=0.19.0` as the main linting tool. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-L50) [[2]](diffhunk://#diff-385cc6fca023baa925097d4b6479d40dba4bbb0c259498ba7a6838829ef5356dL7-L61)

**Linting configuration:**

- Updated the Ruff configuration to explicitly select the D401 rule (docstring first line imperative mood), as it is now compatible with PEP257 and can be checked by Ruff, reducing the need for separate docstring style tools. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L234-R191) [[2]](diffhunk://#diff-385cc6fca023baa925097d4b6479d40dba4bbb0c259498ba7a6838829ef5356dL232-R186)

**Testing logic updates:**

- Changed the test utility `pytest_entry_exists_in_pyproject_toml` to check for the presence of `invokelint[basic]` instead of `pytest` in the generated `pyproject.toml`, and removed the corresponding assertion in the test. [[1]](diffhunk://#diff-9c0244ad96c6475ac8ab290c607bce4552e84008e5aaabb6c98c6ac16262b8d9L339-L340) [[2]](diffhunk://#diff-9c0244ad96c6475ac8ab290c607bce4552e84008e5aaabb6c98c6ac16262b8d9L374-R372)

**Dependency group adjustments:**

- Cleaned up and updated the `dev` dependency group to remove obsolete or unnecessary tools, ensuring a more streamlined and modern development environment.

These changes help modernize and simplify the development setup by consolidating linting and removing redundant or outdated dependencies.